### PR TITLE
_manifest.scss

### DIFF
--- a/scss/_manifest.scss
+++ b/scss/_manifest.scss
@@ -1,0 +1,23 @@
+@import "compass";
+@import "vars";
+@import "base/reset";
+@import "base/normalize";
+
+@import "base/mixins";
+@import "base/grids";
+@import "base/widths";
+@import "base/push";
+@import "base/pull";
+@import "base/island";
+@import "base/lists";
+@import "base/blocks";
+@import "base/shared";
+@import "base/helpers";
+
+@import "ui/fonts";
+@import "ui/typography";
+@import "ui/forms";
+@import "ui/buttons";
+@import "ui/layout";
+
+@import "ui/print";

--- a/scss/application-ie.css.scss
+++ b/scss/application-ie.css.scss
@@ -1,25 +1,3 @@
 $legacy-ie: true;
 
-@import "compass";
-@import "vars";
-@import "base/reset";
-@import "base/normalize";
-
-@import "base/mixins";
-@import "base/grids";
-@import "base/widths";
-@import "base/push";
-@import "base/pull";
-@import "base/island";
-@import "base/lists";
-@import "base/blocks";
-@import "base/shared";
-@import "base/helpers";
-
-@import "ui/fonts";
-@import "ui/typography";
-@import "ui/forms";
-@import "ui/buttons";
-@import "ui/layout";
-
-@import "ui/print";
+@import "manifest";

--- a/scss/application.css.scss
+++ b/scss/application.css.scss
@@ -1,25 +1,3 @@
 $legacy-ie: false;
 
-@import "compass";
-@import "vars";
-@import "base/reset";
-@import "base/normalize";
-
-@import "base/mixins";
-@import "base/grids";
-@import "base/widths";
-@import "base/push";
-@import "base/pull";
-@import "base/island";
-@import "base/lists";
-@import "base/blocks";
-@import "base/shared";
-@import "base/helpers";
-
-@import "ui/fonts";
-@import "ui/typography";
-@import "ui/forms";
-@import "ui/buttons";
-@import "ui/layout";
-
-@import "ui/print";
+@import "manifest";


### PR DESCRIPTION
Making the partial listing a little more DRY by separating it out to `_manifest.scss` that gets included on each of the application files. This way there's no chance of us forgetting to add a partial to the `application-ie.css.scss` file.
