### PR TITLE
clear nth grids mixin

### DIFF
--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -15,6 +15,13 @@
   }
 }
 
+// Clear grid floats
+@mixin n-up($number) {
+  &:nth-child(#{$number}n + 1) {
+    clear: left;
+  }
+}
+
 @mixin inline-block() {
   display: inline-block;
   *display: inline;


### PR DESCRIPTION
After talking to Manderson, this is a very simple approach to clearing grid floats by nth child.  Useful for large grids of repeating blocks that need to line up into pretty rows.  Use this mixin within appropriate media queries to make use of "grid one-half", "lap-one-quarter", etc responsive grid blocks.  This replaces the old "blocks.scss" file.
