### PR TITLE
Remove force-unit function

### DIFF
--- a/scss/base/_functions.scss
+++ b/scss/base/_functions.scss
@@ -21,19 +21,3 @@
     @return $a;
   }
 }
-
-// strip-unit
-//   Returns
-//   from https://github.com/sass/sass/issues/533#issuecomment-11675408
-@function strip-unit($value) {
-  @return $value / ($value * 0 + 1);
-}
-
-// force-unit
-//   Forces the value's unit to the given one.
-//   Returns 0 without units.
-@function force-unit($value, $unit) {
-  // Remove any unit the value may have.
-  $value: strip-unit($value);
-  @return if($value == 0, 0, $value + $unit);
-}

--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -133,20 +133,12 @@
     // Pixel fallbacks.
     // $fallback should be $base-font-size or $base-font-size--mobile.
     @if $fallback {
-      #{$property}: map(
-        force-unit,
-        map(multiply, $rem-values, $fallback),
-        px
-      );
+      #{$property}: map(multiply, $rem-values, $fallback);
     }
-    #{$property}: map(force-unit, $rem-values, rem);
+    #{$property}: map(multiply, $rem-values, 1rem);
   } @else {
     // Calculate pixel values for legacy browsers that don't support rems.
-    #{$property}: map(
-      force-unit,
-      map(multiply, $rem-values, $base-font-size),
-      px
-    );
+    #{$property}: map(multiply, $rem-values, $base-font-size);
   }
 }
 

--- a/tests/media-queries/expected.css
+++ b/tests/media-queries/expected.css
@@ -1,3 +1,7 @@
+/*
+  spaceBase version: 1.0
+  http://spacebase.space150.com
+*/
 @media only screen and (min-width: 768px) {
   div {
     display: none;

--- a/tests/rem-mixin/expected.css
+++ b/tests/rem-mixin/expected.css
@@ -1,3 +1,7 @@
+/*
+  spaceBase version: 1.0
+  http://spacebase.space150.com
+*/
 div {
   margin-left: 4rem;
   padding: 4rem 0 2rem 1rem;

--- a/tests/rem-mixin/expected.css
+++ b/tests/rem-mixin/expected.css
@@ -4,12 +4,12 @@
 */
 div {
   margin-left: 4rem;
-  padding: 4rem 0 2rem 1rem;
+  padding: 4rem 0rem 2rem 1rem;
   font-size: 30px;
   font-size: 2rem;
 }
 
 span {
-  padding: 60px 0 30px 15px;
+  padding: 60px 0px 30px 15px;
   font-size: 30px;
 }


### PR DESCRIPTION
The `force-unit` function was only used in the `@rem` mixin. By evaluating the use cases of the mixin more carefully, @tjdunklee and I realized that it really wasn't necessary to force units. So, this commit removes the function and it's usage in the `@rem` mixin.

This also removes the `strip-unit` function, since it was only used in the `force-unit` function.

This also clears up issue #48.