### PR TITLE
change nth-child to nth-of-type to fix ios8 bug

### DIFF
--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -17,13 +17,13 @@
 
 // Clear grid floats
 @mixin n-up($number) {
-  &:nth-child(#{$number}n + 1) {
+  &:nth-of-type(#{$number}n + 1) {
     clear: left;
   }
 }
 // Clear grid float clears
 @mixin clear-n-up($number) {
-  &:nth-child(#{$number}n + 1) {
+  &:nth-of-type(#{$number}n + 1) {
     clear: none;
   }
 }


### PR DESCRIPTION
This change is to fix this reported bug of iOS8: 
http://stackoverflow.com/questions/26032513/ios8-safari-after-a-pushstate-the-nth-child-selectors-not-works