### PR TITLE
Media Query Mixin Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-### 2.0.2 (Apr 18, 2016)
+### 2.0.2 (Apr 19, 2016)
 
 * Update to Normalize.css 4.1.1.
+* Convert media query mixin from px to em.
+* Fix legacy CSS from including content with type or feature media queries.
+* Remove conditional comments for IE7.
 
 
 ### 2.0.1 (Oct 26, 2015)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 2.0.2 (Apr 19, 2016)
+### 2.1.0 (Apr 19, 2016)
 
 * Update to Normalize.css 4.1.1.
 * Convert media query mixin from px to em.

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<!--[if (lt IE 7) & (!IEMobile)]>     <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if (IE 7) & (!IEMobile)]>        <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if (lt IE 8) & (!IEMobile)]>     <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if (IE 8) & (!IEMobile)]>        <html class="no-js lt-ie9"> <![endif]-->
 <!--[if (IE 9) & (!IEMobile)]>        <html class="no-js lt-ie10"> <![endif]-->
 <!--[if (gt IE 9) | (IEMobile) | !(IE)]><!--> <html class="no-js"> <!--<![endif]-->

--- a/scss/base/_functions.scss
+++ b/scss/base/_functions.scss
@@ -22,6 +22,18 @@
   }
 }
 
+// px2em
+//   Convert pixels to ems
+@function px2em($px) {
+  @if unitless($px) {
+    @warn "Assuming #{$px} to be in pixels, attempting to convert it into pixels.";
+    @return px2em($px * 1px);
+  } @else if unit($px) == em {
+    @return $px;
+  }
+  @return ($px / 16px) * 1em;
+}
+
 // get-breakpoint-width
 //   Get a breakpoint's width from the map.
 @function get-breakpoint-width($name, $breakpoints: $media-breakpoints) {

--- a/scss/base/_grids.scss
+++ b/scss/base/_grids.scss
@@ -7,7 +7,7 @@
 .grid-wrapper {
   list-style: none;
   margin-bottom: 0;
-  @include rem(margin-left, -$gutter, $base-font-size--mobile);
+  @include rem(margin-left, -$gutter);
   @include clearfix;
 }
 
@@ -39,6 +39,6 @@
 .grid {
   float: left;
   width: 100%;
-  @include rem(padding-left, $gutter, $base-font-size--mobile);
+  @include rem(padding-left, $gutter);
   transition: width .15s ease;
 }

--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -90,11 +90,11 @@
 // Rem conversion mixin
 //
 // Converts values to rems for any property passed to it. If optional
-// $fallback is provided, it returns two lines of code: first with the pixel
+// $fallback is provided, it outputs two lines of code: first with the pixel
 // values for non-rem support and a second with the converted rem values.
-// This is necessary for IE9/10 when used with psuedo elements or font
+// This is only necessary for IE9/10 when used with psuedo elements or font
 // shorthand property. Possible $fallback values are $base-font-size or
-// $base-font-size--mobile. This mixin returns just the pixel values to the
+// $base-font-size--mobile. This mixin outputs just the pixel values to the
 // legacy IE CSS file.
 //
 // USAGE:
@@ -123,14 +123,14 @@
 
 @mixin rem($property, $rem-values, $fallback: false) {
   @if not $legacy-ie {
-    // Pixel fallbacks.
-    // $fallback should be $base-font-size or $base-font-size--mobile.
+    // Output pixel fallback
+    // $fallback should be $base-font-size or $base-font-size--mobile
     @if $fallback {
       #{$property}: map(multiply, $rem-values, $fallback);
     }
     #{$property}: map(multiply, $rem-values, 1rem);
   } @else {
-    // Calculate pixel values for legacy browsers that don't support rems.
+    // Calculate pixel values for legacy browsers that don't support rems
     #{$property}: map(multiply, $rem-values, $base-font-size);
   }
 }

--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -190,24 +190,24 @@
   // From: this breakpoint (inclusive)
   @if $from {
     @if type-of($from) == number {
-      $min-width: $from;
+      $min-width: px2em($from);
     } @else if get-breakpoint-width($from) {
-      $min-width: get-breakpoint-width($from);
+      $min-width: px2em(get-breakpoint-width($from));
     }
   }
 
   // Upto: that breakpoint (exclusive)
   @if $upto {
     @if type-of($upto) == number {
-      $max-width: $upto;
+      $max-width: px2em($upto);
     } @else if get-breakpoint-width($upto) {
-      $max-width: get-breakpoint-width($upto) - 1px;
+      $max-width: px2em(get-breakpoint-width($upto)) - .01em;
     }
   }
 
   // Render styles without media queries
   @if $legacy-ie == true {
-    $legacy-breakpoint-width: get-breakpoint-width($legacy-media-breakpoint);
+    $legacy-breakpoint-width: px2em(get-breakpoint-width($legacy-media-breakpoint));
     // Output only rules that start at or span our legacy media width
     @if (
       $min-width <= $legacy-breakpoint-width

--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -210,7 +210,9 @@
     $legacy-breakpoint-width: px2em(get-breakpoint-width($legacy-media-breakpoint));
     // Output only rules that start at or span our legacy media width
     @if (
-      $min-width <= $legacy-breakpoint-width
+      $feature == false
+      and $type == 'screen'
+      and $min-width <= $legacy-breakpoint-width
       and (
         $upto == false or $max-width >= $legacy-breakpoint-width
       )

--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -147,14 +147,15 @@
 //   - for specific media features (e.g. retina, orientation)
 //   - for different media types ($type: print)
 //
-// You can use breakpoint aliases set in $media-breakpoints (in _vars.scss),
-// or custom widths like 480px or 20em.
+// You can use breakpoint aliases set in $media-breakpoints (in _vars.scss)
+// or custom widths. Pixel values will be converted to ems.
 //
 // Commonly-used media features are defined in $media-features (in _vars.scss).
 // You can define additional feature aliases or use custom one-off expressions.
 //
 // It's important to note that $upto is exclusive.
-// This means that `@include media($upto: 780px)` will set a max-width of 779px.
+// This means that `@include media($upto: 768px)` will set a max-width of 
+// 47.99em (roughly 767px).
 //
 // USAGE:
 //
@@ -168,17 +169,18 @@
 //
 // OUTPUT:
 //
-// @media screen and (min-width: 480px) { ... }
-// @media screen and (max-width: 1023px) { ... }
-// @media screen and (min-width: 768px) and (max-width: 1023px) { ... }
-// @media screen and (min-width: 800px) and (max-width: 900px) { ... }
-// @media screen and (max-width: 1023px) and (orientation: landscape) { ... }
+// @media screen and (min-width: 30em) { ... }
+// @media screen and (max-width: 63.99em) { ... }
+// @media screen and (min-width: 48em) and (max-width: 63.99em) { ... }
+// @media screen and (min-width: 50em) and (max-width: 56.25em) { ... }
+// @media screen and (max-width: 63.99em) and (orientation: landscape) { ... }
 // @media print { ... }
 // @media screen and (device-radius: 50%) { ... }
 //
 // OUTPUT TO LEGACY CSS:
 //
-// Only the content needed to render the $legacy-media-breakpoint layout.
+// Only the content needed to render the $legacy-media-breakpoint layout. Any
+// includes with features or types other than screen will be excluded.
 //
 // ***************************************************************************
 

--- a/scss/base/_shared.scss
+++ b/scss/base/_shared.scss
@@ -40,14 +40,14 @@ img[height] { max-width: none; }
   fieldset,figure,figcaption,
   pre {
     margin-top: 0;
-    @include rem(margin-bottom, $base-spacing-unit, $base-font-size--mobile);
+    @include rem(margin-bottom, $base-spacing-unit);
     ul,ol { margin-bottom: 0; }
   }
 
   // Where `margin-left` is concerned, we want to try and indent certain elements
   // by a consistent amount
   ul,ol,dd {
-    @include rem(margin-left, $base-spacing-unit, $base-font-size--mobile);
+    @include rem(margin-left, $base-spacing-unit);
     padding: 0;
   }
 }

--- a/scss/ui/_island.scss
+++ b/scss/ui/_island.scss
@@ -7,25 +7,26 @@
 .islet,
 .landmark {
   display: block;
-  @include rem(margin-bottom, $base-spacing-unit, $base-font-size--mobile);
+  @include rem(margin-bottom, $base-spacing-unit);
   @include clearfix;
+  
   .islet & {
-    @include rem(margin-bottom, $half-spacing-unit, $base-font-size--mobile);
+    @include rem(margin-bottom, $half-spacing-unit);
   }
-
+  
   > :last-child { margin-bottom: 0; }
 }
 
 .island {
-  @include rem(padding-top, $base-spacing-unit, $base-font-size--mobile);
-  @include rem(padding-bottom, $base-spacing-unit, $base-font-size--mobile);
+  @include rem(padding-top, $base-spacing-unit);
+  @include rem(padding-bottom, $base-spacing-unit);
 }
 
 .islet {
-  @include rem(padding-top, $half-spacing-unit, $base-font-size--mobile);
-  @include rem(padding-bottom, $half-spacing-unit, $base-font-size--mobile);
+  @include rem(padding-top, $half-spacing-unit);
+  @include rem(padding-bottom, $half-spacing-unit);
 }
 
 .landmark {
-  @include rem(margin-bottom, 2 * $base-spacing-unit, $base-font-size--mobile);
+  @include rem(margin-bottom, 2 * $base-spacing-unit);
 }

--- a/scss/ui/_layout.scss
+++ b/scss/ui/_layout.scss
@@ -8,6 +8,6 @@ body { min-width: $site-min-width; }
   max-width: $site-wrapper-max-width;
   margin-left: auto;
   margin-right: auto;
-  @include rem(padding-left, $gutter, $base-font-size--mobile);
-  @include rem(padding-right, $gutter, $base-font-size--mobile);
+  @include rem(padding-left, $gutter);
+  @include rem(padding-right, $gutter);
 }

--- a/scss/ui/_lists.scss
+++ b/scss/ui/_lists.scss
@@ -11,7 +11,7 @@
 
 .h-list > li {
   float: left;
-  @include rem(margin-right, $half-spacing-unit, $base-font-size--mobile);
+  @include rem(margin-right, $half-spacing-unit);
 }
 
 .h-list > li:last-child {
@@ -24,10 +24,10 @@
   > li {
     float: none;
     display: inline-block;
-    @include rem(margin, 0 $half-spacing-unit, $base-font-size--mobile);
+    @include rem(margin, 0 $half-spacing-unit);
 
     &:last-child {
-      @include rem(margin-right, $half-spacing-unit, $base-font-size--mobile);
+      @include rem(margin-right, $half-spacing-unit);
     }
   }
 }
@@ -37,13 +37,13 @@
     margin-right: 0;
 
     + li {
-      @include rem(margin-left, $half-spacing-unit, $base-font-size--mobile);
-      @include rem(padding-left, $half-spacing-unit, $base-font-size--mobile);
+      @include rem(margin-left, $half-spacing-unit);
+      @include rem(padding-left, $half-spacing-unit);
       border-left: solid 1px;
     }
   }
 }
 
 .v-list > li {
-  @include rem(margin-top, $half-spacing-unit / 2, $base-font-size--mobile);
+  @include rem(margin-top, $half-spacing-unit / 2);
 }

--- a/scss/ui/_media.scss
+++ b/scss/ui/_media.scss
@@ -7,7 +7,7 @@
 
 .media__item {
   float: left;
-  @include rem(margin-right, $half-spacing-unit, $base-font-size--mobile);
+  @include rem(margin-right, $half-spacing-unit);
 
   img,
   video,
@@ -27,7 +27,7 @@
 .media--flip > .media__item {
   float: right;
   margin-right: 0;
-  @include rem(margin-left, $half-spacing-unit, $base-font-size--mobile);
+  @include rem(margin-left, $half-spacing-unit);
 }
 
 // NOWRAP
@@ -46,7 +46,7 @@
   }
 
   .media__item {
-    @include rem(padding-right, $half-spacing-unit, $base-font-size--mobile);
+    @include rem(padding-right, $half-spacing-unit);
 
     img {
       width: auto !important;

--- a/scss/ui/_print.scss
+++ b/scss/ui/_print.scss
@@ -4,7 +4,7 @@
 
 .visible-print { display: none !important; }
 
-@media print {
+@include media($type: print) {
   * {
     // scss-lint:disable ColorVariable
     background: transparent !important;

--- a/styleguide.html
+++ b/styleguide.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
-<!--[if (lt IE 7) & (!IEMobile)]>     <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if (IE 7) & (!IEMobile)]>        <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if (lt IE 8) & (!IEMobile)]>     <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if (IE 8) & (!IEMobile)]>        <html class="no-js lt-ie9"> <![endif]-->
 <!--[if (IE 9) & (!IEMobile)]>        <html class="no-js lt-ie10"> <![endif]-->
 <!--[if (gt IE 9) | (IEMobile) | !(IE)]><!--> <html class="no-js"> <!--<![endif]-->
@@ -32,26 +31,26 @@
         <div class="grid  one-half">
           <div class="grid-wrapper">
             <div class="grid">
-              <p class="sg-demo-block">Grid 1.1</p>
+              <p class="sg-demo-block">1.1</p>
             </div>
             <div class="grid  one-third">
-              <p class="sg-demo-block">Grid 1.2</p>
+              <p class="sg-demo-block">1.2</p>
             </div>
             <div class="grid  two-thirds">
-              <p class="sg-demo-block">Grid 1.3</p>
+              <p class="sg-demo-block">1.3</p>
             </div>
           </div>
         </div>
         <div class="grid  one-half">
           <div class="grid-wrapper">
             <div class="grid  one-quarter">
-              <p class="sg-demo-block">Grid 2.1</p>
+              <p class="sg-demo-block">2.1</p>
             </div>
             <div class="grid  three-quarters">
-              <p class="sg-demo-block">Grid 2.2</p>
+              <p class="sg-demo-block">2.2</p>
             </div>
             <div class="grid">
-              <p class="sg-demo-block">Grid 2.3</p>
+              <p class="sg-demo-block">2.3</p>
             </div>
           </div>
         </div>
@@ -59,13 +58,13 @@
           <h3 class="sg-heading">Reverse Grid</h3>
           <div class="grid-wrapper  grid-wrapper--rev">
             <div class="grid  one-third">
-              <p class="sg-demo-block">Grid 3.1</p>
+              <p class="sg-demo-block">3.1</p>
             </div>
             <div class="grid  one-third">
-              <p class="sg-demo-block">Grid 3.2</p>
+              <p class="sg-demo-block">3.2</p>
             </div>
             <div class="grid  one-third">
-              <p class="sg-demo-block">Grid 3.3</p>
+              <p class="sg-demo-block">3.3</p>
             </div>
           </div>
         </div>
@@ -73,16 +72,16 @@
           <h3 class="sg-heading">Full Grid</h3>
           <div class="grid-wrapper  grid-wrapper--full">
             <div class="grid  one-eighth">
-              <p class="sg-demo-block">Grid 4.1</p>
+              <p class="sg-demo-block">4.1</p>
             </div>
             <div class="grid  two-eighths">
-              <p class="sg-demo-block">Grid 4.2</p>
+              <p class="sg-demo-block">4.2</p>
             </div>
             <div class="grid  three-eighths">
-              <p class="sg-demo-block">Grid 4.3</p>
+              <p class="sg-demo-block">4.3</p>
             </div>
             <div class="grid  two-eighths">
-              <p class="sg-demo-block">Grid 4.4</p>
+              <p class="sg-demo-block">4.4</p>
             </div>
           </div>
         </div>
@@ -90,10 +89,10 @@
           <h3 class="sg-heading">Push and Pull</h3>
           <div class="grid-wrapper">
             <div class="grid  one-quarter  push--one-quarter">
-              <p class="sg-demo-block">Grid 5.1</p>
+              <p class="sg-demo-block">5.1</p>
             </div>
             <div class="grid  one-quarter  push--one-quarter">
-              <p class="sg-demo-block">Grid 5.2</p>
+              <p class="sg-demo-block">5.2</p>
             </div>
           </div>
         </div>
@@ -106,40 +105,40 @@
         <div class="grid  one-half">
           <div class="grid-wrapper">
             <div class="grid">
-              <p class="sg-demo-block">Grid 1.1</p>
+              <p class="sg-demo-block">1.1</p>
             </div>
             <div class="grid  lap-one-whole  desk-one-third">
-              <p class="sg-demo-block">Grid 1.2</p>
+              <p class="sg-demo-block">1.2</p>
             </div>
             <div class="grid  lap-one-whole  desk-two-thirds">
-              <p class="sg-demo-block">Grid 1.3</p>
+              <p class="sg-demo-block">1.3</p>
             </div>
           </div>
         </div>
         <div class="grid  one-half">
           <div class="grid-wrapper">
             <div class="grid  one-half">
-              <p class="sg-demo-block">Grid 2.1</p>
+              <p class="sg-demo-block">2.1</p>
             </div>
             <div class="grid  one-half">
-              <p class="sg-demo-block">Grid 2.2</p>
+              <p class="sg-demo-block">2.2</p>
             </div>
             <div class="grid  lap-one-half  desk-one-third">
-              <p class="sg-demo-block">Grid 2.3</p>
+              <p class="sg-demo-block">2.3</p>
             </div>
             <div class="grid  lap-one-half  desk-one-third">
-              <p class="sg-demo-block">Grid 2.4</p>
+              <p class="sg-demo-block">2.4</p>
             </div>
             <div class="grid  desk-one-third">
-              <p class="sg-demo-block">Grid 2.5</p>
+              <p class="sg-demo-block">2.5</p>
             </div>
           </div>
         </div>
         <div class="grid  hand-one-half  lap-one-quarter desk-two-fifths">
-          <p class="sg-demo-block">Grid 3.0</p>
+          <p class="sg-demo-block">3.0</p>
         </div>
         <div class="grid  hand-one-half  lap-three-quarters desk-three-fifths">
-          <p class="sg-demo-block">Grid 4.0</p>
+          <p class="sg-demo-block">4.0</p>
         </div>
       </div>
     </div>

--- a/test/media/basic.css
+++ b/test/media/basic.css
@@ -1,30 +1,30 @@
-@media screen and (min-width: 480px) {
+@media screen and (min-width: 30em) {
   div { display: none; }
 }
-@media screen and (max-width: 479px) {
-  div { display: none; }
-}
-
-
-@media screen and (min-width: 768px) {
-  div { display: none; }
-}
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 29.99em) {
   div { display: none; }
 }
 
 
-@media screen and (min-width: 1024px) {
+@media screen and (min-width: 48em) {
   div { display: none; }
 }
-@media screen and (max-width: 1023px) {
+@media screen and (max-width: 47.99em) {
   div { display: none; }
 }
 
 
-@media screen and (min-width: 1200px) {
+@media screen and (min-width: 64em) {
   div { display: none; }
 }
-@media screen and (max-width: 1199px) {
+@media screen and (max-width: 63.99em) {
+  div { display: none; }
+}
+
+
+@media screen and (min-width: 75em) {
+  div { display: none; }
+}
+@media screen and (max-width: 74.99em) {
   div { display: none; }
 }

--- a/test/rem-mixin/rem-mixin.css
+++ b/test/rem-mixin/rem-mixin.css
@@ -1,7 +1,3 @@
-/*
-  spaceBase version: 1.0
-  http://spacebase.space150.com
-*/
 div {
   margin-left: 4rem;
   padding: 4rem 0rem 2rem 1rem;


### PR DESCRIPTION
It's clear from this article on PX, EM, REM Media Queries (http://zellwk.com/blog/media-query-units/), EM's are the winner for bug-free responsive websites no matter how the user changes their zoom level or font size. We've updated our media query mixin to support this, and it now converts all pixel values to ems. Also included in this enhancements upgrade:
- fix for the legacy fallback to exclude content with type or feature media queries 
- remove conditional comments for IE7
- other code cleanup with mixin usage
