### PR TITLE
Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### 3.0.0 (Sept 9, 2016)
+### 3.0.0 (Dec 20, 2016)
 
 * Replace rem() mixin with rem function.
 * Add padding mixins.
+* Add plain anchor helper.
 * Populate styleguide color swatches dynamically.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ### 3.0.0 (Dec 20, 2016)
 
 * Replace rem() mixin with rem function.
+* Calculate $base-spacing-unit once.
 * Add padding mixins.
 * Add plain anchor helper.
+* Add landmarklet class.
+* Update form styles for better cross browser uniformity.
 * Populate styleguide color swatches dynamically.
+* Update to Normalize.css 5.0.0.
 
 
 ### 2.1.0 (Apr 19, 2016)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    commander (4.3.5)
+    commander (4.4.2)
       highline (~> 1.7.2)
-    highline (1.7.7)
-    minitest (5.8.1)
-    rainbow (2.0.0)
-    rake (10.4.2)
-    sass (3.4.18)
-    sassunit (1.0.0)
+    highline (1.7.8)
+    minitest (5.10.1)
+    rainbow (2.1.0)
+    rake (12.0.0)
+    sass (3.4.23)
+    sassunit (1.0.2)
       commander
       minitest
       sass
@@ -25,4 +25,4 @@ DEPENDENCIES
   scss_lint (= 0.38.0)
 
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/scss/base/_grids.scss
+++ b/scss/base/_grids.scss
@@ -40,5 +40,4 @@
   float: left;
   width: 100%;
   @include rem(padding-left, $gutter);
-  transition: width .15s ease;
 }

--- a/scss/base/_helpers.scss
+++ b/scss/base/_helpers.scss
@@ -74,3 +74,11 @@
   display: table-cell;
   vertical-align: middle;
 }
+
+// Remove styling of anchor, useful for large clickable content areas
+.anchor-plain {
+  color: inherit;
+  &:hover, &:focus {
+    text-decoration: none;
+  }
+}

--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -52,9 +52,9 @@
 // Placeholder text
 @mixin placeholder {
   // scss-lint:disable VendorPrefix
-  &:-moz-placeholder { @content; } // Firefox 4-18
-  &::-moz-placeholder { opacity: 1; @content; } // Firefox 19+
-  &:-ms-input-placeholder { @content; } // Internet Explorer 10+
+  &::-moz-placeholder { @content; } // Firefox 19+
+  &:-ms-input-placeholder { @content; } // IE 10+
+  &::-ms-input-placeholder { @content; } // Edge
   &::-webkit-input-placeholder { @content; } // Safari and Chrome
 }
 

--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -43,8 +43,6 @@
 
 // WebKit-style focus
 @mixin tab-focus {
-  // scss-lint:disable DuplicateProperty
-  outline: thin dotted #333;
   outline: 5px auto -webkit-focus-ring-color;
   outline-offset: -2px;
 }

--- a/scss/base/_shared.scss
+++ b/scss/base/_shared.scss
@@ -50,4 +50,9 @@ img[height] { max-width: none; }
     @include rem(margin-left, $base-spacing-unit);
     padding: 0;
   }
+  
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
 }

--- a/scss/ui/_forms.scss
+++ b/scss/ui/_forms.scss
@@ -90,23 +90,30 @@ input[type="checkbox"]:focus { @include tab-focus; }
   border: 1px solid $gray;
   border-radius: 0;
   transition: border-color ease-in-out .15s;
+  
+  // Unstyle the caret on `<select>`s in IE10+
+  &::-ms-expand {
+    background-color: transparent;
+    border: 0;
+  }
 
   // Customize the `:focus` state to imitate native WebKit styles
   @include form-control-focus;
 
   // Placeholder
-  @include placeholder { color: $primary; }
+  @include placeholder {
+    color: $primary;
+    opacity: 1; // Override Firefox's unusual default opacity; see https://github.com/twbs/bootstrap/pull/11526
+  }
 
   // Disabled and read-only inputs
   &[disabled],
-  &[readonly],
-  fieldset[disabled] & {
+  &[readonly] {
     background-color: $gray-light;
     opacity: 1; // iOS fix for unreadable disabled content; see https://github.com/twbs/bootstrap/issues/11655
   }
 
-  &[disabled],
-  fieldset[disabled] & {
+  &[disabled] {
     cursor: not-allowed;
   }
 }

--- a/scss/ui/_forms.scss
+++ b/scss/ui/_forms.scss
@@ -142,6 +142,7 @@ textarea.form-control {
   margin-bottom: 10px;
 
   label {
+    display: inline-block;
     min-height: $base-line-height; // Ensure the input doesn't jump when there is no text
     padding-left: 22px;
     margin-bottom: 0;

--- a/scss/ui/_island.scss
+++ b/scss/ui/_island.scss
@@ -8,12 +8,7 @@
 .landmark,
 .landmarklet {
   display: block;
-  @include rem(margin-bottom, $base-spacing-unit);
   @include clearfix;
-  
-  .islet & {
-    @include rem(margin-bottom, $half-spacing-unit);
-  }
   
   > :last-child { margin-bottom: 0; }
 }

--- a/scss/ui/_island.scss
+++ b/scss/ui/_island.scss
@@ -5,7 +5,8 @@
 // Harry Robert's "island"
 .island,
 .islet,
-.landmark {
+.landmark,
+.landmarklet {
   display: block;
   @include rem(margin-bottom, $base-spacing-unit);
   @include clearfix;
@@ -29,4 +30,8 @@
 
 .landmark {
   @include rem(margin-bottom, 2 * $base-spacing-unit);
+}
+
+.landmarklet {
+  @include rem(margin-bottom, $base-spacing-unit);
 }

--- a/scss/ui/_typography.scss
+++ b/scss/ui/_typography.scss
@@ -13,7 +13,7 @@ a {
   color: $primary;
   text-decoration: none;
 
-  &:hover { text-decoration: underline; }
+  &:hover, &:focus { text-decoration: underline; }
 }
 
 i { font-style: normal; }

--- a/scss/vendor/_normalize.scss
+++ b/scss/vendor/_normalize.scss
@@ -1,15 +1,24 @@
-/*! normalize.css v4.1.1 | MIT License | github.com/necolas/normalize.css */
+/*! normalize.css v5.0.0 | MIT License | github.com/necolas/normalize.css */
+
+/* Document
+   ========================================================================== */
 
 /**
  * 1. Change the default font family in all browsers (opinionated).
- * 2. Prevent adjustments of font size after orientation changes in IE and iOS.
+ * 2. Correct the line height in all browsers.
+ * 3. Prevent adjustments of font size after orientation changes in
+ *    IE on Windows Phone and in iOS.
  */
 
 html {
   font-family: sans-serif; /* 1 */
-  -ms-text-size-adjust: 100%; /* 2 */
-  -webkit-text-size-adjust: 100%; /* 2 */
+  line-height: 1.15; /* 2 */
+  -ms-text-size-adjust: 100%; /* 3 */
+  -webkit-text-size-adjust: 100%; /* 3 */
 }
+
+/* Sections
+   ========================================================================== */
 
 /**
  * Remove the margin in all browsers (opinionated).
@@ -19,69 +28,73 @@ body {
   margin: 0;
 }
 
-/* HTML5 display definitions
-   ========================================================================== */
-
 /**
  * Add the correct display in IE 9-.
- * 1. Add the correct display in Edge, IE, and Firefox.
- * 2. Add the correct display in IE.
  */
 
 article,
 aside,
-details, /* 1 */
-figcaption,
-figure,
 footer,
 header,
-main, /* 2 */
-menu,
 nav,
-section,
-summary { /* 1 */
+section {
   display: block;
 }
 
 /**
+ * Correct the font size and margin on `h1` elements within `section` and
+ * `article` contexts in Chrome, Firefox, and Safari.
+ */
+
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+
+/* Grouping content
+   ========================================================================== */
+
+/**
  * Add the correct display in IE 9-.
- */
-
-audio,
-canvas,
-progress,
-video {
-  display: inline-block;
-}
-
-/**
- * Add the correct display in iOS 4-7.
- */
-
-audio:not([controls]) {
-  display: none;
-  height: 0;
-}
-
-/**
- * Add the correct vertical alignment in Chrome, Firefox, and Opera.
- */
-
-progress {
-  vertical-align: baseline;
-}
-
-/**
- * Add the correct display in IE 10-.
  * 1. Add the correct display in IE.
  */
 
-template, /* 1 */
-[hidden] {
-  display: none;
+figcaption,
+figure,
+main { /* 1 */
+  display: block;
 }
 
-/* Links
+/**
+ * Add the correct margin in IE 8.
+ */
+
+figure {
+  margin: 1em 40px;
+}
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  box-sizing: content-box; /* 1 */
+  height: 0; /* 1 */
+  overflow: visible; /* 2 */
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+pre {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/* Text-level semantics
    ========================================================================== */
 
 /**
@@ -103,9 +116,6 @@ a:active,
 a:hover {
   outline-width: 0;
 }
-
-/* Text-level semantics
-   ========================================================================== */
 
 /**
  * 1. Remove the bottom border in Firefox 39-.
@@ -137,21 +147,23 @@ strong {
 }
 
 /**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: monospace, monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
  * Add the correct font style in Android 4.3-.
  */
 
 dfn {
   font-style: italic;
-}
-
-/**
- * Correct the font size and margin on `h1` elements within `section` and
- * `article` contexts in Chrome, Firefox, and Safari.
- */
-
-h1 {
-  font-size: 2em;
-  margin: 0.67em 0;
 }
 
 /**
@@ -196,6 +208,24 @@ sup {
    ========================================================================== */
 
 /**
+ * Add the correct display in IE 9-.
+ */
+
+audio,
+video {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in iOS 4-7.
+ */
+
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+
+/**
  * Remove the border on images inside links in IE 10-.
  */
 
@@ -211,46 +241,11 @@ svg:not(:root) {
   overflow: hidden;
 }
 
-/* Grouping content
-   ========================================================================== */
-
-/**
- * 1. Correct the inheritance and scaling of font size in all browsers.
- * 2. Correct the odd `em` font sizing in all browsers.
- */
-
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace, monospace; /* 1 */
-  font-size: 1em; /* 2 */
-}
-
-/**
- * Add the correct margin in IE 8.
- */
-
-figure {
-  margin: 1em 40px;
-}
-
-/**
- * 1. Add the correct box sizing in Firefox.
- * 2. Show the overflow in Edge and IE.
- */
-
-hr {
-  box-sizing: content-box; /* 1 */
-  height: 0; /* 1 */
-  overflow: visible; /* 2 */
-}
-
 /* Forms
    ========================================================================== */
 
 /**
- * 1. Change font properties to `inherit` in all browsers (opinionated).
+ * 1. Change the font styles in all browsers (opinionated).
  * 2. Remove the margin in Firefox and Safari.
  */
 
@@ -259,16 +254,10 @@ input,
 optgroup,
 select,
 textarea {
-  font: inherit; /* 1 */
+  font-family: sans-serif; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
   margin: 0; /* 2 */
-}
-
-/**
- * Restore the font weight unset by the previous rule.
- */
-
-optgroup {
-  font-weight: bold;
 }
 
 /**
@@ -354,6 +343,16 @@ legend {
 }
 
 /**
+ * 1. Add the correct display in IE 9-.
+ * 2. Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  display: inline-block; /* 1 */
+  vertical-align: baseline; /* 2 */
+}
+
+/**
  * Remove the default vertical scrollbar in IE.
  */
 
@@ -392,21 +391,12 @@ textarea {
 }
 
 /**
- * Remove the inner padding and cancel buttons in Chrome and Safari on OS X.
+ * Remove the inner padding and cancel buttons in Chrome and Safari on macOS.
  */
 
 [type="search"]::-webkit-search-cancel-button,
 [type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
-}
-
-/**
- * Correct the text style of placeholders in Chrome, Edge, and Safari.
- */
-
-::-webkit-input-placeholder {
-  color: inherit;
-  opacity: 0.54;
 }
 
 /**
@@ -417,4 +407,55 @@ textarea {
 ::-webkit-file-upload-button {
   -webkit-appearance: button; /* 1 */
   font: inherit; /* 2 */
+}
+
+/* Interactive
+   ========================================================================== */
+
+/*
+ * Add the correct display in IE 9-.
+ * 1. Add the correct display in Edge, IE, and Firefox.
+ */
+
+details, /* 1 */
+menu {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/* Scripting
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 9-.
+ */
+
+canvas {
+  display: inline-block;
+}
+
+/**
+ * Add the correct display in IE.
+ */
+
+template {
+  display: none;
+}
+
+/* Hidden
+   ========================================================================== */
+
+/**
+ * Add the correct display in IE 10-.
+ */
+
+[hidden] {
+  display: none;
 }


### PR DESCRIPTION
Couple of enhancements:
1. Version 4 of Normalize removed the table border styles because they said it was too opinionated. I think it makes sense to be in spaceBase, so I moved it to `_shared.scss` only if normalize is chosen. It still exists in the CSS reset.
2. Something I often need is a link styling reset for large clickable areas such as cards and tiles. Picture a image with text and the whole thing is inside a link, but you don't want the text to take on the default link styles and colors. If you add this helper class to the anchor tag, the color will stay dark and not underline. I pulled this from another client, so am totally open to changing the name of it. This was the original, of which I removed a lot of the resets. Do you think we should include all this? Have ideas for names?

```
.anchor--plain {
  color: inherit;
  letter-spacing: normal;
  font-family: $font-body;
  font-style: normal;
  text-transform: none;
  &:hover, &:focus {
    text-decoration: none;
  }
}
```
1. Default link hover state should be the same as focus state.
2. In newer versions of IE and Edge, the grid transition occurs on each page load, making some weird looking sliding animations. This transition doesn't have much benefit anyway, so let's remove it. This does, however, bring up the question of any transitions occurring on page load (IE seems to be the worst offender). Does anyone have a solution for that, such as [this](https://css-tricks.com/transitions-only-after-page-load/)? 

Does anyone have any other helpers they'd like to add or discuss?
