### PR TITLE
Replace rem mixin with rem function

### DIFF
--- a/scss/base/_functions.scss
+++ b/scss/base/_functions.scss
@@ -53,3 +53,43 @@
     @return false;
   }
 }
+
+
+// ***************************************************************************
+// Rem conversion mixin
+//
+// Renders the given values as rems in the normal stylesheet, and as pixels in
+// the legacy-ie stylesheet.
+//
+// USAGE:
+//
+// .element {
+//    padding: rem(4 0 2 1);
+//    font-size: rem(2);
+// }
+//
+// OUTPUT:
+//
+// .element {
+//    padding: 4rem 0 2rem 1rem;
+//    font-size: 2rem;
+// }
+//
+// OUTPUT TO LEGACY CSS:
+//
+// .element {
+//    padding: 64px 0 32px 16px;
+//    font-size: 32px;
+// }
+//
+// ***************************************************************************
+
+@function rem($rem-values) {
+  @if not $legacy-ie {
+    @return map(multiply, $rem-values, 1rem);
+  } @else {
+    // Calculate pixel values for legacy browsers that don't support rems
+    @return map(multiply, $rem-values, $base-font-size);
+  }
+}
+

--- a/scss/base/_grids.scss
+++ b/scss/base/_grids.scss
@@ -7,7 +7,7 @@
 .grid-wrapper {
   list-style: none;
   margin-bottom: 0;
-  @include rem(margin-left, -$gutter);
+  margin-left: rem(-$gutter);
   @include clearfix;
 }
 
@@ -39,6 +39,6 @@
 .grid {
   float: left;
   width: 100%;
-  @include rem(padding-left, $gutter);
+  padding-left: rem($gutter);
   transition: width .15s ease;
 }

--- a/scss/base/_mixins.scss
+++ b/scss/base/_mixins.scss
@@ -87,56 +87,6 @@
 
 
 // ***************************************************************************
-// Rem conversion mixin
-//
-// Converts values to rems for any property passed to it. If optional
-// $fallback is provided, it outputs two lines of code: first with the pixel
-// values for non-rem support and a second with the converted rem values.
-// This is only necessary for IE9/10 when used with psuedo elements or font
-// shorthand property. Possible $fallback values are $base-font-size or
-// $base-font-size--mobile. This mixin outputs just the pixel values to the
-// legacy IE CSS file.
-//
-// USAGE:
-//
-// .element {
-//    @include rem(padding, 4 0 2 1);
-//    @include rem(font-size, 2, $base-font-size);
-// }
-//
-// OUTPUT:
-//
-// .element {
-//    padding: 4rem 0 2rem 1rem;
-//    font-size: 32px;
-//    font-size: 2rem;
-// }
-//
-// OUTPUT TO LEGACY CSS:
-//
-// .element {
-//    padding: 64px 0 32px 16px;
-//    font-size: 32px;
-// }
-//
-// ***************************************************************************
-
-@mixin rem($property, $rem-values, $fallback: false) {
-  @if not $legacy-ie {
-    // Output pixel fallback
-    // $fallback should be $base-font-size or $base-font-size--mobile
-    @if $fallback {
-      #{$property}: map(multiply, $rem-values, $fallback);
-    }
-    #{$property}: map(multiply, $rem-values, 1rem);
-  } @else {
-    // Calculate pixel values for legacy browsers that don't support rems
-    #{$property}: map(multiply, $rem-values, $base-font-size);
-  }
-}
-
-
-// ***************************************************************************
 // Media query mixin
 //
 // When using spaceBase, styles should be written mobile-first.

--- a/scss/base/_shared.scss
+++ b/scss/base/_shared.scss
@@ -40,14 +40,14 @@ img[height] { max-width: none; }
   fieldset,figure,figcaption,
   pre {
     margin-top: 0;
-    @include rem(margin-bottom, $base-spacing-unit);
+    margin-bottom: rem($base-spacing-unit);
     ul,ol { margin-bottom: 0; }
   }
 
   // Where `margin-left` is concerned, we want to try and indent certain elements
   // by a consistent amount
   ul,ol,dd {
-    @include rem(margin-left, $base-spacing-unit);
+    margin-left: rem($base-spacing-unit);
     padding: 0;
   }
 }

--- a/scss/styleguide.scss
+++ b/scss/styleguide.scss
@@ -4,7 +4,7 @@ $legacy-ie: true;
 @import "base/mixins";
 
 .sg-landmark {
-  @include rem(margin-bottom, 3 * $base-spacing-unit);
+  margin-bottom: rem(3 * $base-spacing-unit);
 }
 
 .sg-heading {
@@ -15,15 +15,15 @@ $legacy-ie: true;
 .sg-demo-block {
   background-color: $gray;
   color: $white;
-  @include rem(padding, $half-spacing-unit);
-  @include rem(margin, 0 0 $base-spacing-unit);
+  padding: rem($half-spacing-unit);
+  margin: rem(0 0 $base-spacing-unit);
 }
 
 .sg-colors li {
   border: 1px solid $gray-light;
   background: $white;
-  @include rem(padding, .4);
-  @include rem(margin-bottom, $half-spacing-unit);
+  padding: rem(.4);
+  margin-bottom: rem($half-spacing-unit);
 }
 
 .sg-swatch {

--- a/scss/ui/_buttons.scss
+++ b/scss/ui/_buttons.scss
@@ -6,7 +6,7 @@
   display: inline-block;
   margin: 0;
   padding: .4em 1em;
-  @include rem(font-size, 1);
+  font-size: rem(1);
   line-height: 1.6em;
   text-align: center;
   vertical-align: middle;

--- a/scss/ui/_forms.scss
+++ b/scss/ui/_forms.scss
@@ -81,7 +81,7 @@ input[type="checkbox"]:focus { @include tab-focus; }
   height: 2.5em;
   padding: .2em 1em;
   font-family: $font-body;
-  @include rem(font-size, 1);
+  font-size: rem(1);
   line-height: $line-height-ratio;
   color: $gray-dark;
   vertical-align: middle;

--- a/scss/ui/_island.scss
+++ b/scss/ui/_island.scss
@@ -7,26 +7,26 @@
 .islet,
 .landmark {
   display: block;
-  @include rem(margin-bottom, $base-spacing-unit);
+  margin-bottom: rem($base-spacing-unit);
   @include clearfix;
-  
+
   .islet & {
-    @include rem(margin-bottom, $half-spacing-unit);
+    margin-bottom: rem($half-spacing-unit);
   }
-  
+
   > :last-child { margin-bottom: 0; }
 }
 
 .island {
-  @include rem(padding-top, $base-spacing-unit);
-  @include rem(padding-bottom, $base-spacing-unit);
+  padding-top: rem($base-spacing-unit);
+  padding-bottom: rem($base-spacing-unit);
 }
 
 .islet {
-  @include rem(padding-top, $half-spacing-unit);
-  @include rem(padding-bottom, $half-spacing-unit);
+  padding-top: rem($half-spacing-unit);
+  padding-bottom: rem($half-spacing-unit);
 }
 
 .landmark {
-  @include rem(margin-bottom, 2 * $base-spacing-unit);
+  margin-bottom: rem(2 * $base-spacing-unit);
 }

--- a/scss/ui/_layout.scss
+++ b/scss/ui/_layout.scss
@@ -8,6 +8,6 @@ body { min-width: $site-min-width; }
   max-width: $site-wrapper-max-width;
   margin-left: auto;
   margin-right: auto;
-  @include rem(padding-left, $gutter);
-  @include rem(padding-right, $gutter);
+  padding-left: rem($gutter);
+  padding-right: rem($gutter);
 }

--- a/scss/ui/_lists.scss
+++ b/scss/ui/_lists.scss
@@ -11,7 +11,7 @@
 
 .h-list > li {
   float: left;
-  @include rem(margin-right, $half-spacing-unit);
+  margin-right: rem($half-spacing-unit);
 }
 
 .h-list > li:last-child {
@@ -24,10 +24,10 @@
   > li {
     float: none;
     display: inline-block;
-    @include rem(margin, 0 $half-spacing-unit);
+    margin: rem(0 $half-spacing-unit);
 
     &:last-child {
-      @include rem(margin-right, $half-spacing-unit);
+      margin-right: rem($half-spacing-unit);
     }
   }
 }
@@ -37,13 +37,13 @@
     margin-right: 0;
 
     + li {
-      @include rem(margin-left, $half-spacing-unit);
-      @include rem(padding-left, $half-spacing-unit);
+      margin-left: rem($half-spacing-unit);
+      padding-left: rem($half-spacing-unit);
       border-left: solid 1px;
     }
   }
 }
 
 .v-list > li {
-  @include rem(margin-top, $half-spacing-unit / 2);
+  margin-top: rem($half-spacing-unit / 2);
 }

--- a/scss/ui/_media.scss
+++ b/scss/ui/_media.scss
@@ -7,7 +7,7 @@
 
 .media__item {
   float: left;
-  @include rem(margin-right, $half-spacing-unit);
+  margin-right: rem($half-spacing-unit);
 
   img,
   video,
@@ -27,7 +27,7 @@
 .media--flip > .media__item {
   float: right;
   margin-right: 0;
-  @include rem(margin-left, $half-spacing-unit);
+  margin-left: rem($half-spacing-unit);
 }
 
 // NOWRAP
@@ -46,7 +46,7 @@
   }
 
   .media__item {
-    @include rem(padding-right, $half-spacing-unit);
+    padding-right: rem($half-spacing-unit);
 
     img {
       width: auto !important;

--- a/scss/ui/_typography.scss
+++ b/scss/ui/_typography.scss
@@ -29,30 +29,30 @@ h6, .h6 {
 }
 
 h1, .h1 {
-  @include rem(font-size, 1.875);
+  font-size: rem(1.875);
   line-height: 1;
 }
 
 h2, .h2 {
-  @include rem(font-size, 1.25);
+  font-size: rem(1.25);
   line-height: 1.2;
 }
 
 h3, .h3 {
-  @include rem(font-size, 1);
+  font-size: rem(1);
   line-height: 1.4;
 }
 
 h4, .h4 {
-  @include rem(font-size, .875);
+  font-size: rem(.875);
 }
 
 @include media($from: lap) {
-  h1, .h1 { @include rem(font-size, 3.6); }
+  h1, .h1 { font-size: rem(3.6); }
 
-  h2, .h2 { @include rem(font-size, 2.4); }
+  h2, .h2 { font-size: rem(2.4); }
 
-  h3, .h3 { @include rem(font-size, 1.5); }
+  h3, .h3 { font-size: rem(1.5); }
 
-  h4, .h4 { @include rem(font-size, 1.2); }
+  h4, .h4 { font-size: rem(1.2); }
 }


### PR DESCRIPTION
Using a function instead of a mixin means we can change call sites like this:

```scss
.foo {
  @include rem(margin, 2);
  // to
  margin: rem(2);
}
```

This puts the property first, which is great for visual consistency/scanning. It's also a lot less characters/noise.

Passing multiple values still works, e.g. `padding: rem(0 1 3)`.

We could also store `$base-spacing-unit` and friends like this:

```scss
$base-spacing-unit: rem($line-height-ratio);

// later...
.island {
  padding-top: $base-spacing-unit;
  padding-bottom: $base-spacing-unit;
}
```

This wasn't possible before because the rem mixin had to run at each `@include` to calculate the pixel values.