### PR TITLE
Calculate $base-spacing-unit's value once

### DIFF
--- a/scss/_manifest.scss
+++ b/scss/_manifest.scss
@@ -1,10 +1,10 @@
+@import "base/functions";
 @import "vars";
 
 // Choose either Normalize or Reset:
 @import "vendor/normalize"; $normalize: true;
 // @import "vendor/reset"; $reset: true;
 
-@import "base/functions";
 @import "base/mixins";
 @import "base/grids";
 @import "base/widths";

--- a/scss/_vars.scss
+++ b/scss/_vars.scss
@@ -29,7 +29,8 @@ $base-font-size--mobile: $base-font-size;
 
 // Calculated measurements
 $line-height-ratio: $base-line-height / $base-font-size;
-$base-spacing-unit: $line-height-ratio;
+
+$base-spacing-unit: rem($line-height-ratio);
 $half-spacing-unit: $base-spacing-unit / 2;
 
 // Grid

--- a/scss/base/_functions.scss
+++ b/scss/base/_functions.scss
@@ -85,10 +85,21 @@
 // ***************************************************************************
 
 @function rem($rem-values) {
+  @if length($rem-values) > 1 {
+    @return rem-list($rem-values);
+  }
+  @if not $legacy-ie {
+    @return $rem-values * 1rem;
+  } @else {
+    // Calculate pixel values for legacy browsers that don't support rems
+    @return $rem-values * $base-font-size;
+  }
+}
+
+@function rem-list($rem-values) {
   @if not $legacy-ie {
     @return map(multiply, $rem-values, 1rem);
   } @else {
-    // Calculate pixel values for legacy browsers that don't support rems
     @return map(multiply, $rem-values, $base-font-size);
   }
 }

--- a/scss/base/_grids.scss
+++ b/scss/base/_grids.scss
@@ -7,7 +7,7 @@
 .grid-wrapper {
   list-style: none;
   margin-bottom: 0;
-  margin-left: rem(-$gutter);
+  margin-left: -$gutter;
   @include clearfix;
 }
 
@@ -39,6 +39,6 @@
 .grid {
   float: left;
   width: 100%;
-  padding-left: rem($gutter);
+  padding-left: $gutter;
   transition: width .15s ease;
 }

--- a/scss/base/_shared.scss
+++ b/scss/base/_shared.scss
@@ -40,14 +40,14 @@ img[height] { max-width: none; }
   fieldset,figure,figcaption,
   pre {
     margin-top: 0;
-    margin-bottom: rem($base-spacing-unit);
+    margin-bottom: $base-spacing-unit;
     ul,ol { margin-bottom: 0; }
   }
 
   // Where `margin-left` is concerned, we want to try and indent certain elements
   // by a consistent amount
   ul,ol,dd {
-    margin-left: rem($base-spacing-unit);
+    margin-left: $base-spacing-unit;
     padding: 0;
   }
 }

--- a/scss/ui/_island.scss
+++ b/scss/ui/_island.scss
@@ -7,26 +7,26 @@
 .islet,
 .landmark {
   display: block;
-  margin-bottom: rem($base-spacing-unit);
+  margin-bottom: $base-spacing-unit;
   @include clearfix;
 
   .islet & {
-    margin-bottom: rem($half-spacing-unit);
+    margin-bottom: $half-spacing-unit;
   }
 
   > :last-child { margin-bottom: 0; }
 }
 
 .island {
-  padding-top: rem($base-spacing-unit);
-  padding-bottom: rem($base-spacing-unit);
+  padding-top: $base-spacing-unit;
+  padding-bottom: $base-spacing-unit;
 }
 
 .islet {
-  padding-top: rem($half-spacing-unit);
-  padding-bottom: rem($half-spacing-unit);
+  padding-top: $half-spacing-unit;
+  padding-bottom: $half-spacing-unit;
 }
 
 .landmark {
-  margin-bottom: rem(2 * $base-spacing-unit);
+  margin-bottom: 2 * $base-spacing-unit;
 }

--- a/scss/ui/_layout.scss
+++ b/scss/ui/_layout.scss
@@ -8,6 +8,7 @@ body { min-width: $site-min-width; }
   max-width: $site-wrapper-max-width;
   margin-left: auto;
   margin-right: auto;
-  padding-left: rem($gutter);
-  padding-right: rem($gutter);
+  padding-left: $gutter;
+  padding-right: $gutter;
 }
+

--- a/scss/ui/_lists.scss
+++ b/scss/ui/_lists.scss
@@ -11,7 +11,7 @@
 
 .h-list > li {
   float: left;
-  margin-right: rem($half-spacing-unit);
+  margin-right: $half-spacing-unit;
 }
 
 .h-list > li:last-child {
@@ -24,10 +24,10 @@
   > li {
     float: none;
     display: inline-block;
-    margin: rem(0 $half-spacing-unit);
+    margin: 0 $half-spacing-unit;
 
     &:last-child {
-      margin-right: rem($half-spacing-unit);
+      margin-right: $half-spacing-unit;
     }
   }
 }
@@ -37,13 +37,13 @@
     margin-right: 0;
 
     + li {
-      margin-left: rem($half-spacing-unit);
-      padding-left: rem($half-spacing-unit);
+      margin-left: $half-spacing-unit;
+      padding-left: $half-spacing-unit;
       border-left: solid 1px;
     }
   }
 }
 
 .v-list > li {
-  margin-top: rem($half-spacing-unit / 2);
+  margin-top: $half-spacing-unit / 2;
 }

--- a/scss/ui/_media.scss
+++ b/scss/ui/_media.scss
@@ -7,7 +7,7 @@
 
 .media__item {
   float: left;
-  margin-right: rem($half-spacing-unit);
+  margin-right: $half-spacing-unit;
 
   img,
   video,
@@ -27,7 +27,7 @@
 .media--flip > .media__item {
   float: right;
   margin-right: 0;
-  margin-left: rem($half-spacing-unit);
+  margin-left: $half-spacing-unit;
 }
 
 // NOWRAP
@@ -46,7 +46,7 @@
   }
 
   .media__item {
-    padding-right: rem($half-spacing-unit);
+    padding-right: $half-spacing-unit;
 
     img {
       width: auto !important;


### PR DESCRIPTION
As mentioned in #63, now that `rem` is a function we can calculate the value of `$base-spacing-unit` once in `_vars.scss` and avoid using the `rem` function in a lot of places in the rest of the codebase.
