### PR TITLE
fix bug with fluid images that have explicit height attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 4.2.1 (Jun 27, 2022)
+
+* Fix fluid images that have height attribute.
+
+
 ### 4.2.0 (Mar 2, 2022)
 
 * Replace / divider with math.div().
@@ -5,7 +10,7 @@
 * Remove i rule.
 
 
-### 4.1.0 (June 24, 2021)
+### 4.1.0 (Jun 24, 2021)
 
 * Add sass npm scripts for compilation.
 * Remove CSS Reset option.
@@ -16,7 +21,7 @@
 * Update to Normalize.css 8.0.1.
 
 
-### 4.0.0 (June 11, 2018)
+### 4.0.0 (Jun 11, 2018)
 
 * Refactor grid system to use flexbox instead of floats.
 * Remove media object.

--- a/scss/_vars.scss
+++ b/scss/_vars.scss
@@ -4,7 +4,7 @@
 //------------------------------------//
 
 /*
-  spaceBase version: 4.2.0
+  spaceBase version: 4.2.1
   http://spacebase.space150.com
 */
 

--- a/scss/base/_shared.scss
+++ b/scss/base/_shared.scss
@@ -10,7 +10,6 @@
   &:after { box-sizing: border-box; }
 }
 
-
 // Remove gap between elements and the bottom of their containers
 audio,
 canvas,
@@ -22,6 +21,10 @@ video { vertical-align: middle; }
 img {
   max-width: 100%;
   -ms-interpolation-mode: bicubic;
+}
+
+img[height] {
+  height: auto;
 }
 
 // Where `margin-bottom` is concerned, this value will be the same as the

--- a/scss/base/_shared.scss
+++ b/scss/base/_shared.scss
@@ -23,9 +23,7 @@ img {
   -ms-interpolation-mode: bicubic;
 }
 
-img[height] {
-  height: auto;
-}
+img[height] { height: auto; }
 
 // Where `margin-bottom` is concerned, this value will be the same as the
 // base line-height. This allows us to keep a consistent vertical rhythm.


### PR DESCRIPTION
Added to _shared.scss:
`img[height] { height: auto; }`